### PR TITLE
[FEATURE] Provide dynamic return types for Query->execute() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This extension provides the following features:
 * Provides correct return type for `\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()`.
 * Provides correct return type for `\TYPO3\CMS\Extbase\Object\ObjectManagerInterface->get()`.
 * Provides correct return type for `\TYPO3\CMS\Extbase\Object\ObjectManager->get()`.
+* Provides correct return type for `\TYPO3\CMS\Extbase\Persistence\Generic\Query->execute()`.
+* Provides correct return type for `\TYPO3\CMS\Extbase\Persistence\QueryInterface->execute()`.
 
 <details>
   <summary>Details on GeneralUtility::makeInstance()</summary>

--- a/extension.neon
+++ b/extension.neon
@@ -19,3 +19,11 @@ services:
     class: FriendsOfTYPO3\PHPStan\TYPO3\Type\ObjectManagerInterfaceGetDynamicReturnTypeExtension
     tags:
       - phpstan.broker.dynamicMethodReturnTypeExtension
+  -
+    class: FriendsOfTYPO3\PHPStan\TYPO3\Type\QueryExecuteReturnTypeExtension
+    tags:
+      - phpstan.broker.dynamicMethodReturnTypeExtension
+  -
+    class: FriendsOfTYPO3\PHPStan\TYPO3\Type\QueryInterfaceExecuteReturnTypeExtension
+    tags:
+      - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/QueryExecuteReturnTypeExtension.php
+++ b/src/Type/QueryExecuteReturnTypeExtension.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\PHPStan\TYPO3\Type;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_ as StringNode;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use TYPO3\CMS\Extbase\Persistence\Generic\Query;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+class QueryExecuteReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Query::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'execute';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
+    {
+        if (empty($methodCall->args)) {
+            return new ObjectType(QueryResultInterface::class);
+        }
+
+        $firstArgument = $scope->getType($methodCall->args[0]->value);
+        if (!$firstArgument instanceof ConstantBooleanType) {
+            throw new \InvalidArgumentException(
+                'Argument $returnRawQueryResult is not a boolean.',
+                1584879250
+            );
+        }
+
+        $returnRawQueryResult = $firstArgument->getValue();
+        if ($returnRawQueryResult) {
+            return new ArrayType(
+                new StringType(),
+                new MixedType()
+            );
+        }
+
+        return new ObjectType(QueryResultInterface::class);
+    }
+}

--- a/src/Type/QueryInterfaceExecuteReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceExecuteReturnTypeExtension.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\PHPStan\TYPO3\Type;
+
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_ as StringNode;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use TYPO3\CMS\Extbase\Persistence\Generic\Query;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+class QueryInterfaceExecuteReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return QueryInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'execute';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
+    {
+        if (empty($methodCall->args)) {
+            return new ObjectType(QueryResultInterface::class);
+        }
+
+        $firstArgument = $scope->getType($methodCall->args[0]->value);
+        if (!$firstArgument instanceof ConstantBooleanType) {
+            throw new \InvalidArgumentException(
+                'Argument $returnRawQueryResult is not a boolean.',
+                1584879250
+            );
+        }
+
+        $returnRawQueryResult = $firstArgument->getValue();
+        if ($returnRawQueryResult) {
+            return new ArrayType(
+                new StringType(),
+                new MixedType()
+            );
+        }
+
+        return new ObjectType(QueryResultInterface::class);
+    }
+}


### PR DESCRIPTION
The method execute() of the QueryInterface does return a
QueryResultInterface by default. However, if the argument
$returnRawQueryResult is sset to true, an array is returned
instead.

This patch provides the correct return types for all calls
on the QueryInterface and the Query implementation on extbase.