### PR TITLE
[TASK] Ensure working with phpstan ^0.12.99 and ~/^1.2.0 in core 10.4, 11.5 and main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         "typo3/cms-extbase": "^10.4 || 11.*.*@dev"
     },
     "config": {
-        "platform": {
-            "php": "7.2"
-        },
-        "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true,
             "ergebnis/composer-normalize": true
-        }
+        },
+        "platform": {
+            "php": "7.2"
+        },
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^7.2 || ^8.0 || ^8.1",
-        "phpstan/phpstan": "^0.12.44"
+        "phpstan/phpstan": "^0.12.99 || ^1.2.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "TYPO3 rules for PHPStan",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.2 || ^8.0 || ^8.1",
         "phpstan/phpstan": "^0.12.44"
     },
     "require-dev": {
@@ -19,7 +19,13 @@
         "platform": {
             "php": "7.2"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true,
+            "ergebnis/composer-normalize": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2429daa14912975daa78dec72c5ba58",
+    "content-hash": "6256332673487bf024e89e36dedfb93d",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -8261,11 +8261,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.2 || ^8.0 || ^8.1"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6256332673487bf024e89e36dedfb93d",
+    "content-hash": "46469f6e5b49fd1dc0cad7ab29adbcf3",
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.44",
+            "version": "0.12.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "330b45776ea77f167b150e24787412414a8fa469"
+                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/330b45776ea77f167b150e24787412414a8fa469",
-                "reference": "330b45776ea77f167b150e24787412414a8fa469",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
                 "shasum": ""
             },
             "require": {
@@ -48,11 +48,15 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.44"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
             },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
                     "type": "github"
                 },
                 {
@@ -64,7 +68,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-24T15:28:47+00:00"
+            "time": "2021-09-12T20:09:55+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull-requests incorporate the minimum changes,
so phpstan can be installed and used with ^0.12.99 
and ~1.2.0 (not tested yet for >= phpstan 1.3.0).

This basicly enables to raise to phpstan 1.2.0 and
execute phpstan with PHP8.1, as the 0.12.x version
emits a lot of depcrecations from the binary itself,
even if tested sources are ok/green - which is a lot
of spamming noice and not clean.


Later this should be branched and version ranges made,
so we can cleanup this for phpstan >= 1.2.0 and Typo3
Core v12/main and min PHP8.1 version.

Tested with phpstan 0.12.99 in:

- 10.4 branch (with phpstan update)
- 11.5 branch (only this fork/branch/pr)
- main branch this fork/branch/pr

and all still green.

On main with this fork and phpstan raised to
1.2.0 overwork of phpstan configuration in the
core repository is needed to fix breaking changes
and handle new findings (ignore, rule configuration
and so on).

For core main with this fork a (red) work in progress
patch exists:

73037: [WIP][TASK] Update phpstan to work when run with PHP8.1 
https://review.typo3.org/c/Packages/TYPO3.CMS/+/73037